### PR TITLE
Open neighbors

### DIFF
--- a/assets/css/components/_board.scss
+++ b/assets/css/components/_board.scss
@@ -8,6 +8,7 @@
     display: flex;
     flex-flow: column nowrap;
     margin: 2rem;
+    user-select: none;
 
     .row {
       display: flex;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -30,6 +30,15 @@ const hooks = {
 
         this.pushEventTo('#board', 'flag-cell', { x, y })
       })
+
+      this.el.addEventListener('dblclick', (e) => {
+        e.preventDefault()
+
+        const x = this.el.getAttribute('phx-value-x')
+        const y = this.el.getAttribute('phx-value-y')
+
+        this.pushEventTo('#board', 'open-neighbors', { x, y })
+      })
     }
   }
 }

--- a/lib/nyon/minesweeper/board.ex
+++ b/lib/nyon/minesweeper/board.ex
@@ -131,6 +131,9 @@ defmodule Nyon.Minesweeper.Board do
       nil ->
         board
 
+      %Cell{mine: true} ->
+        gameover(board)
+
       %Cell{state: state} when state in [:flag, :closed] ->
         board
 

--- a/lib/nyon/minesweeper/board.ex
+++ b/lib/nyon/minesweeper/board.ex
@@ -140,12 +140,13 @@ defmodule Nyon.Minesweeper.Board do
       %Cell{state: :open, mine: false, neighbor: n} ->
         neighbor_coords = neighbor_coords({x, y})
 
-        flag_count = Enum.count(neighbor_coords, fn coord ->
-          case Map.get(cells, coord) do
-            nil -> false
-            cell -> cell.state == :flag
-          end
-        end)
+        flag_count =
+          Enum.count(neighbor_coords, fn coord ->
+            case Map.get(cells, coord) do
+              nil -> false
+              cell -> cell.state == :flag
+            end
+          end)
 
         if flag_count == n do
           Enum.all?(neighbor_coords, fn coord ->
@@ -156,23 +157,24 @@ defmodule Nyon.Minesweeper.Board do
           end)
           |> case do
             true ->
-              cells = Enum.reduce(neighbor_coords, cells, fn coord, cells ->
-                case Map.get(cells, coord) do
-                  nil ->
-                    cells
+              cells =
+                Enum.reduce(neighbor_coords, cells, fn coord, cells ->
+                  case Map.get(cells, coord) do
+                    nil ->
+                      cells
 
-                  %Cell{state: state} when state in [:flag, :open] ->
-                    cells
+                    %Cell{state: state} when state in [:flag, :open] ->
+                      cells
 
-                  %Cell{state: :closed, mine: false, neighbor: 0} ->
-                    cells
-                    |> Map.update!({x, y}, &Cell.open/1)
-                    |> safe_open_neighbors({x, y})
+                    %Cell{state: :closed, mine: false, neighbor: 0} ->
+                      cells
+                      |> Map.update!({x, y}, &Cell.open/1)
+                      |> safe_open_neighbors({x, y})
 
-                  %Cell{state: :closed} ->
-                    Map.update!(cells, coord, &Cell.open/1)
-                end
-              end)
+                    %Cell{state: :closed} ->
+                      Map.update!(cells, coord, &Cell.open/1)
+                  end
+                end)
 
               %__MODULE__{board | cells: cells}
 

--- a/lib/nyon/minesweeper/board.ex
+++ b/lib/nyon/minesweeper/board.ex
@@ -47,6 +47,10 @@ defmodule Nyon.Minesweeper.Board do
     end)
   end
 
+  def open_cell(board = %__MODULE__{gameover: true}) do
+    board
+  end
+
   def open_cell(board = %__MODULE__{cells: cells}, {x, y}) do
     case do_open_cell(cells, {x, y}) do
       {:ok, cells} ->
@@ -108,10 +112,18 @@ defmodule Nyon.Minesweeper.Board do
     board
   end
 
+  def flag_cell(board = %__MODULE__{gameover: true}) do
+    board
+  end
+
   def flag_cell(board = %__MODULE__{cells: cells}, {x, y}) do
     cells = Map.update!(cells, {x, y}, &Cell.toggle_flag/1)
 
     %__MODULE__{board | cells: cells}
+  end
+
+  def open_neighbors(board = %__MODULE__{gameover: true}) do
+    board
   end
 
   def open_neighbors(board = %__MODULE__{cells: cells}, {x, y}) do

--- a/lib/nyon/minesweeper/board.ex
+++ b/lib/nyon/minesweeper/board.ex
@@ -149,6 +149,11 @@ defmodule Nyon.Minesweeper.Board do
                   %Cell{state: state} when state in [:flag, :open] ->
                     cells
 
+                  %Cell{state: :closed, mine: false, neighbor: 0} ->
+                    cells
+                    |> Map.update!({x, y}, &Cell.open/1)
+                    |> safe_open_neighbors({x, y})
+
                   %Cell{state: :closed} ->
                     Map.update!(cells, coord, &Cell.open/1)
                 end

--- a/lib/nyon/minesweeper/server.ex
+++ b/lib/nyon/minesweeper/server.ex
@@ -21,6 +21,10 @@ defmodule Nyon.Minesweeper.Server do
     GenServer.call(@name, {:flag_cell, coord})
   end
 
+  def open_neighbors(coord) do
+    GenServer.call(@name, {:open_neighbors, coord})
+  end
+
   def reset do
     GenServer.call(@name, :reset)
   end
@@ -43,6 +47,12 @@ defmodule Nyon.Minesweeper.Server do
 
   def handle_call({:flag_cell, coord}, _from, board) do
     board = Board.flag_cell(board, coord)
+
+    {:reply, board, board}
+  end
+
+  def handle_call({:open_neighbors, coord}, _from, board) do
+    board = Board.open_neighbors(board, coord)
 
     {:reply, board, board}
   end

--- a/lib/nyon_web/live/components/minesweeper_board.ex
+++ b/lib/nyon_web/live/components/minesweeper_board.ex
@@ -36,6 +36,15 @@ defmodule NyonWeb.Components.MinesweeperBoard do
   end
 
   @impl true
+  def handle_event("open-neighbors", %{"x" => x, "y" => y}, socket) do
+    coord = {String.to_integer(x), String.to_integer(y)}
+    board = Server.open_neighbors(coord)
+    Phoenix.PubSub.broadcast(Nyon.PubSub, "board:1", :update_board)
+
+    {:noreply, assign(socket, :board, board)}
+  end
+
+  @impl true
   def handle_event("restart", _, socket) do
     :ok = Server.reset()
     Phoenix.PubSub.broadcast(Nyon.PubSub, "board:1", :update_board)


### PR DESCRIPTION
When adjacent flags are all on mines, double clicking the number opens neighbors except flagged cells. If flags are not on mine cells, the game will over.