### PR TITLE
Single click to open neighbor cells

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -30,15 +30,6 @@ const hooks = {
 
         this.pushEventTo('#board', 'flag-cell', { x, y })
       })
-
-      this.el.addEventListener('dblclick', (e) => {
-        e.preventDefault()
-
-        const x = this.el.getAttribute('phx-value-x')
-        const y = this.el.getAttribute('phx-value-y')
-
-        this.pushEventTo('#board', 'open-neighbors', { x, y })
-      })
     }
   }
 }

--- a/lib/nyon/minesweeper/board.ex
+++ b/lib/nyon/minesweeper/board.ex
@@ -52,12 +52,18 @@ defmodule Nyon.Minesweeper.Board do
   end
 
   def open_cell(board = %__MODULE__{cells: cells}, {x, y}) do
-    case do_open_cell(cells, {x, y}) do
-      {:ok, cells} ->
-        %__MODULE__{board | cells: cells}
+    case Map.get(cells, {x, y}) do
+      %Cell{state: :open} ->
+        open_neighbors(board, {x, y})
 
-      :boom ->
-        gameover(board)
+      _closed_cell ->
+        case do_open_cell(cells, {x, y}) do
+          {:ok, cells} ->
+            %__MODULE__{board | cells: cells}
+
+          :boom ->
+            gameover(board)
+        end
     end
   end
 
@@ -122,11 +128,11 @@ defmodule Nyon.Minesweeper.Board do
     %__MODULE__{board | cells: cells}
   end
 
-  def open_neighbors(board = %__MODULE__{gameover: true}, _coord) do
+  defp open_neighbors(board = %__MODULE__{gameover: true}, _coord) do
     board
   end
 
-  def open_neighbors(board = %__MODULE__{cells: cells}, {x, y}) do
+  defp open_neighbors(board = %__MODULE__{cells: cells}, {x, y}) do
     case Map.get(cells, {x, y}) do
       nil ->
         board

--- a/lib/nyon/minesweeper/server.ex
+++ b/lib/nyon/minesweeper/server.ex
@@ -21,10 +21,6 @@ defmodule Nyon.Minesweeper.Server do
     GenServer.call(@name, {:flag_cell, coord})
   end
 
-  def open_neighbors(coord) do
-    GenServer.call(@name, {:open_neighbors, coord})
-  end
-
   def reset do
     GenServer.call(@name, :reset)
   end
@@ -47,12 +43,6 @@ defmodule Nyon.Minesweeper.Server do
 
   def handle_call({:flag_cell, coord}, _from, board) do
     board = Board.flag_cell(board, coord)
-
-    {:reply, board, board}
-  end
-
-  def handle_call({:open_neighbors, coord}, _from, board) do
-    board = Board.open_neighbors(board, coord)
 
     {:reply, board, board}
   end

--- a/lib/nyon_web/live/components/minesweeper_board.ex
+++ b/lib/nyon_web/live/components/minesweeper_board.ex
@@ -36,15 +36,6 @@ defmodule NyonWeb.Components.MinesweeperBoard do
   end
 
   @impl true
-  def handle_event("open-neighbors", %{"x" => x, "y" => y}, socket) do
-    coord = {String.to_integer(x), String.to_integer(y)}
-    board = Server.open_neighbors(coord)
-    Phoenix.PubSub.broadcast(Nyon.PubSub, "board:1", :update_board)
-
-    {:noreply, assign(socket, :board, board)}
-  end
-
-  @impl true
   def handle_event("restart", _, socket) do
     :ok = Server.reset()
     Phoenix.PubSub.broadcast(Nyon.PubSub, "board:1", :update_board)

--- a/test/nyon/minesweeper/board_test.exs
+++ b/test/nyon/minesweeper/board_test.exs
@@ -28,6 +28,45 @@ defmodule Nyon.Minesweeper.BoardTest do
       assert %Board{gameover: true} = Board.open_cell(board, {2, 2})
     end
 
+    test "opens neighbor safe cells if correctly flagged", %{board: board} do
+      board = %Board{cells: cells} = Board.open_cell(board, {1, 0})
+
+      assert %Cell{state: :open} = Map.get(cells, {2, 0})
+      assert %Cell{state: :open} = Map.get(cells, {2, 1})
+      refute board.gameover
+    end
+
+    test "opens continuous 0-mine cells", %{board: board} do
+      board = %Board{cells: cells} = Board.open_cell(board, {1, 0})
+
+      assert %Cell{state: :open} = Map.get(cells, {2, 0})
+      assert %Cell{state: :open} = Map.get(cells, {3, 0})
+      assert %Cell{state: :open} = Map.get(cells, {2, 1})
+      assert %Cell{state: :open} = Map.get(cells, {3, 1})
+      refute board.gameover
+    end
+
+    test "has no effect if flags is not enough", %{board: board} do
+      %Board{cells: cells} = Board.open_cell(board, {1, 1})
+
+      assert %Cell{state: :closed} = Map.get(cells, {2, 0})
+    end
+
+    test "has no effect if num of flags is more than num of neighbor mines", %{board: board} do
+      board = Board.flag_cell(board, {2, 0})
+      %Board{cells: cells} = Board.open_cell(board, {1, 0})
+
+      assert %Cell{state: :flag} = Map.get(cells, {2, 0})
+      assert %Cell{state: :closed} = Map.get(cells, {2, 1})
+    end
+
+    test "gameover if incorrectly flagged", %{board: board} do
+      board = Board.flag_cell(board, {2, 0})
+      board = Board.open_cell(board, {1, 1})
+
+      assert board.gameover
+    end
+
     test "has no effect on finished game", %{board: board} do
       board = %Board{board | gameover: true}
       board = %Board{cells: %{{2, 0} => cell}} = Board.open_cell(board, {2, 0})
@@ -57,58 +96,6 @@ defmodule Nyon.Minesweeper.BoardTest do
       board = %Board{cells: %{{2, 2} => cell}} = Board.flag_cell(board, {2, 2})
 
       assert cell.state == :closed
-      assert board.gameover
-    end
-  end
-
-  describe "open_neighbors/2" do
-    setup [:build_board]
-
-    test "opens neighbor safe cells if correctly flagged", %{board: board} do
-      board = %Board{cells: cells} = Board.open_neighbors(board, {1, 0})
-
-      assert %Cell{state: :open} = Map.get(cells, {2, 0})
-      assert %Cell{state: :open} = Map.get(cells, {2, 1})
-      refute board.gameover
-    end
-
-    test "opens continuous 0-mine cells", %{board: board} do
-      board = %Board{cells: cells} = Board.open_neighbors(board, {1, 0})
-
-      assert %Cell{state: :open} = Map.get(cells, {2, 0})
-      assert %Cell{state: :open} = Map.get(cells, {3, 0})
-      assert %Cell{state: :open} = Map.get(cells, {2, 1})
-      assert %Cell{state: :open} = Map.get(cells, {3, 1})
-      refute board.gameover
-    end
-
-    test "has no effect if flags is not enough", %{board: board} do
-      %Board{cells: cells} = Board.open_neighbors(board, {1, 1})
-
-      assert %Cell{state: :closed} = Map.get(cells, {2, 0})
-    end
-
-    test "has no effect if num of flags is more than num of neighbor mines", %{board: board} do
-      board = Board.flag_cell(board, {2, 0})
-      %Board{cells: cells} = Board.open_neighbors(board, {1, 0})
-
-      assert %Cell{state: :flag} = Map.get(cells, {2, 0})
-      assert %Cell{state: :closed} = Map.get(cells, {2, 1})
-    end
-
-    test "gameover if incorrectly flagged", %{board: board} do
-      board = Board.flag_cell(board, {2, 0})
-      board = Board.open_neighbors(board, {1, 1})
-
-      assert board.gameover
-    end
-
-    test "has no effect on finished game", %{board: board} do
-      board = %Board{board | gameover: true}
-      board = %Board{cells: cells} = Board.open_neighbors(board, {1, 0})
-
-      assert %Cell{state: :closed} = Map.get(cells, {2, 0})
-      assert %Cell{state: :closed} = Map.get(cells, {2, 1})
       assert board.gameover
     end
   end


### PR DESCRIPTION
Noticed there is no reason double click to be assigned to open-neighbors command. It is ok to handle single click as open-cell if the cell is closed, as open-neighbors if open.